### PR TITLE
Fixed support for iOS 6

### DIFF
--- a/Classes/M13BadgeView.m
+++ b/Classes/M13BadgeView.m
@@ -214,7 +214,11 @@
     }
     //Calculate the width of the text
     CGFloat widthPadding = ceilf(_font.pointSize * .375);
-    CGSize textSize = [string boundingRectWithSize:CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX) options:NSStringDrawingUsesLineFragmentOrigin attributes:@{NSFontAttributeName : _font} context:nil].size;
+    
+    NSAttributedString *attributedString = [[NSAttributedString alloc] initWithString:(string ? string : @"") attributes:@{NSFontAttributeName : _font}];
+                                                                                                          
+    CGSize textSize = [attributedString boundingRectWithSize:(CGSize){CGFLOAT_MAX, CGFLOAT_MAX} options:NSStringDrawingUsesLineFragmentOrigin context:nil].size;
+    
     if (include) {
         textSize.width += widthPadding * 2;
     }


### PR DESCRIPTION
The podspec for this project lists iOS 6 as the minimum version supported, however M13BadgeView calls `NSString`'s `- (CGRect)boundingRectWithSize:(CGSize)size options:(NSStringDrawingOptions)options attributes:(NSDictionary *)attributes context:(NSStringDrawingContext *)context`, which is an iOS 7 only method.

This pull request fixes support for iOS 6 by creating an `NSAttributedString` and using the iOS 6 method `- (CGRect)boundingRectWithSize:(CGSize)size options:(NSStringDrawingOptions)options context:(NSStringDrawingContext *)context`.

An alternate solution to this would be to drop support for iOS 6 by modifying the podspec.

(shout out to [Deploymate](http://www.deploymateapp.com) for helping me pinpoint this issue).
