### PR TITLE
Enable alignment shift for text to resolve issues with certain fonts

### DIFF
--- a/Classes/M13BadgeView.h
+++ b/Classes/M13BadgeView.h
@@ -37,6 +37,8 @@ typedef enum {
 @property (nonatomic, retain) UIColor *textColor;
 /**The font of the text.*/
 @property (nonatomic, retain) UIFont *font;
+/**The distance to shift the text by when the horizontal/vertical alignment is set. This is for fine tune adjustments.*/
+@property (nonatomic, assign) CGSize textAlignmentShift;
 
 /**@name Badge*/
 /**The background color of the badge.*/

--- a/Classes/M13BadgeView.m
+++ b/Classes/M13BadgeView.m
@@ -196,7 +196,7 @@
     self.frame = frame;
     CGRect tempFrame = CGRectMake(0, 0, frame.size.width, frame.size.height);
     backgroundLayer.frame = tempFrame;
-    CGRect textFrame = CGRectMake(0, (ceilf(self.frame.size.height - _font.lineHeight) / 2), self.frame.size.width, _font.lineHeight);
+    CGRect textFrame = CGRectMake(self.textAlignmentShift.width, (ceilf(self.frame.size.height - _font.lineHeight) / 2) + self.textAlignmentShift.height, self.frame.size.width, _font.lineHeight);
     textLayer.frame = textFrame;
     glossLayer.frame = tempFrame;
     glossMaskLayer.frame = tempFrame;

--- a/Classes/M13BadgeView.m
+++ b/Classes/M13BadgeView.m
@@ -60,6 +60,7 @@
     
     //Set the default
     _textColor = [UIColor whiteColor];
+    _textAlignmentShift = CGSizeZero;
     _font = [UIFont systemFontOfSize:16.0];
     _badgeBackgroundColor = [UIColor redColor];
     _showGloss = NO;
@@ -233,7 +234,7 @@
 {
     [super layoutSubviews];
     //Update the frames of the layers
-    CGRect textFrame = CGRectMake(0, (ceilf(self.frame.size.height - _font.lineHeight) / 2), self.frame.size.width, _font.lineHeight);
+    CGRect textFrame = CGRectMake(self.textAlignmentShift.width, (ceilf(self.frame.size.height - _font.lineHeight) / 2) + self.textAlignmentShift.height, self.frame.size.width, _font.lineHeight);
     textLayer.frame = textFrame;
     backgroundLayer.frame = CGRectMake(0, 0, self.bounds.size.width, self.bounds.size.height);
     glossLayer.frame = CGRectMake(0, 0, self.bounds.size.width, self.bounds.size.height);


### PR DESCRIPTION
Certain fonts need a bit of fine tuning. The screenshots show Source Sans Pro

**Before:**
![before](https://cloud.githubusercontent.com/assets/119219/3874279/1a6e755c-213f-11e4-845d-05783f601095.png)
**After**
![after](https://cloud.githubusercontent.com/assets/119219/3874280/1f217cc0-213f-11e4-9254-e64d67202db5.png)
